### PR TITLE
Fix scaling of rpi PWM driver

### DIFF
--- a/hal/driver_test.go
+++ b/hal/driver_test.go
@@ -131,8 +131,8 @@ func TestRpiDriver_GetPWMChannel(t *testing.T) {
 	backingChannel := ch.(*channel)
 	backingDriver := backingChannel.driver.(*mockPwmDriver)
 
-	if s := backingDriver.setting[0]; s != 100000 {
-		t.Errorf("backing driver not reporting 100000, got %d", s)
+	if s := backingDriver.setting[0]; s != 1000000 {
+		t.Errorf("backing driver not reporting 1000000, got %d", s)
 	}
 	if !backingDriver.enabled[0] {
 		t.Error("backing driver was not enabled")

--- a/hal/pwm.go
+++ b/hal/pwm.go
@@ -33,7 +33,7 @@ func (p *channel) Set(value float64) error {
 		return err
 	}
 
-	setting := float64(p.frequency/1000) * value
+	setting := float64(p.frequency/100) * value
 	if err := p.driver.DutyCycle(p.pin, int(setting)); err != nil {
 		return err
 	}


### PR DESCRIPTION
The duty cycle was under scaled by 10x due to a bad transcription
change in the HAL refactor