### PR TITLE
(bug)Fix RPI PWM driver

### DIFF
--- a/hal/driver.go
+++ b/hal/driver.go
@@ -69,7 +69,7 @@ func NewAdapter(s Settings, pd pwm.Driver, factory PinFactory) (*driver, error) 
 		ch := &channel{
 			pin:       p,
 			driver:    pd,
-			frequency: s.PWMFreq * 100000,
+			frequency: s.PWMFreq,
 			name:      fmt.Sprintf("%d", p),
 		}
 		d.channels[p] = ch

--- a/hal/driver.go
+++ b/hal/driver.go
@@ -15,7 +15,7 @@ type DigitalPin interface {
 }
 
 type Settings struct {
-	PWMFreq int
+	PWMFreq int `json:"pwm_freq"`
 }
 
 type driver struct {

--- a/hal/pwm.go
+++ b/hal/pwm.go
@@ -34,8 +34,7 @@ func (p *channel) Set(value float64) error {
 		return err
 	}
 
-	setting := float64(p.frequency/100) * value
-	if err := p.driver.DutyCycle(p.pin, int(setting)); err != nil {
+	if err := p.driver.DutyCycle(p.pin, int(value)); err != nil {
 		return err
 	}
 	if err := p.driver.Enable(p.pin); err != nil {

--- a/hal/pwm.go
+++ b/hal/pwm.go
@@ -2,6 +2,7 @@ package hal
 
 import (
 	"fmt"
+	"log"
 	"sort"
 
 	"github.com/reef-pi/hal"
@@ -17,8 +18,9 @@ type channel struct {
 }
 
 func (p *channel) Set(value float64) error {
-	if p.frequency == 0 {
-		p.frequency = 100
+	if p.frequency <= 0 {
+		log.Printf("warning: RPI PWM frequency is 0, defaulting to 150")
+		p.frequency = 150
 	}
 	if value < 0 || value > 100 {
 		return fmt.Errorf("value must be 0-100, got %f", value)

--- a/hal/pwm.go
+++ b/hal/pwm.go
@@ -17,6 +17,9 @@ type channel struct {
 }
 
 func (p *channel) Set(value float64) error {
+	if p.frequency == 0 {
+		p.frequency = 100
+	}
 	if value < 0 || value > 100 {
 		return fmt.Errorf("value must be 0-100, got %f", value)
 	}
@@ -33,7 +36,6 @@ func (p *channel) Set(value float64) error {
 	if err := p.driver.Frequency(p.pin, p.frequency); err != nil {
 		return err
 	}
-
 	if err := p.driver.DutyCycle(p.pin, int(value)); err != nil {
 		return err
 	}

--- a/pwm/driver.go
+++ b/pwm/driver.go
@@ -67,7 +67,8 @@ func (d *driver) DutyCycle(ch, duty int) error {
 	if err != nil {
 		return err
 	}
-	freq, err := strconv.ParseInt(string(data), 10, 64)
+	sdata := strings.TrimRight(string(data), "\n")
+	freq, err := strconv.ParseInt(sdata, 10, 64)
 	if err != nil {
 		return err
 	}

--- a/pwm/driver.go
+++ b/pwm/driver.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,7 @@ func New() Driver {
 	return &driver{
 		sysfs:     SysFS,
 		writeFile: ioutil.WriteFile,
+		readFile:  ioutil.ReadFile,
 	}
 }
 
@@ -36,8 +38,13 @@ func toS(ch int) []byte {
 	return []byte(fmt.Sprintf("%d\n", ch))
 }
 
+func toS64(value int64) []byte {
+	return []byte(fmt.Sprintf("%d\n", value))
+}
+
 type driver struct {
 	writeFile func(file string, data []byte, perm os.FileMode) error
+	readFile  func(file string) ([]byte, error)
 	sysfs     string
 }
 
@@ -51,14 +58,31 @@ func (d *driver) Unexport(ch int) error {
 	return d.writeFile(file, toS(ch), 0600)
 }
 
+// DutyCycle sets the duty cycle as a 0-100 percentage of the
+// given period of the driver. Does not assume the Frequency
+// method has been called.
 func (d *driver) DutyCycle(ch, duty int) error {
+	freqFile := filepath.Join(d.sysfs, fmt.Sprintf("pwm%d", ch), "period")
+	data, err := d.readFile(freqFile)
+	if err != nil {
+		return err
+	}
+	freq, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+	nanoSecondsDuty := int64((float64(duty) / 100.0) * float64(freq))
+
 	file := filepath.Join(d.sysfs, fmt.Sprintf("pwm%d", ch), "duty_cycle")
-	return d.writeFile(file, toS(duty), 0644)
+	return d.writeFile(file, toS64(nanoSecondsDuty), 0644)
 }
 
+// Frequency sets the frequency in Hz. This is written as nano-seconds to the
+// period register in the underlying sysfs pwm driver.
 func (d *driver) Frequency(ch, freq int) error {
+	period := int64((1.0/(float64(freq))) * 1.0e9)
 	file := filepath.Join(d.sysfs, fmt.Sprintf("pwm%d", ch), "period")
-	return d.writeFile(file, toS(freq), 0644)
+	return d.writeFile(file, toS64(period), 0644)
 }
 
 func (d *driver) Enable(ch int) error {

--- a/pwm/driver.go
+++ b/pwm/driver.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	SysFS = "/sys/class/pwm/pwmchip0"
-	PeriodScale = 1
 )
 
 type Driver interface {
@@ -85,7 +84,7 @@ func (d *driver) DutyCycle(ch, duty int) error {
 // so we need to check this first, and reset the duty_cycle if this
 // is the case.
 func (d *driver) Frequency(ch, freq int) error {
-	period := int64((1.0/(float64(freq))) * 1.0e9 * PeriodScale)
+	period := int64((1.0/(float64(freq))) * 1.0e9)
 	dutyCycleFile := filepath.Join(d.sysfs, fmt.Sprintf("pwm%d", ch), "duty_cycle")
 	data, err := d.readFile(dutyCycleFile)
 	if err != nil {

--- a/pwm/noop_driver.go
+++ b/pwm/noop_driver.go
@@ -21,6 +21,9 @@ func Noop() (Driver, *recorder) {
 			return nil
 		},
 		readFile: func(f string) ([]byte, error) {
+			if _, ok := rec.values[f]; !ok {
+				return []byte{}, nil
+			}
 			return rec.values[f], nil
 		},
 	}

--- a/pwm/noop_driver.go
+++ b/pwm/noop_driver.go
@@ -20,6 +20,9 @@ func Noop() (Driver, *recorder) {
 			rec.values[f] = c
 			return nil
 		},
+		readFile: func(f string) ([]byte, error) {
+			return rec.values[f], nil
+		},
 	}
 	return d, rec
 }


### PR DESCRIPTION
- Perform math to set the period correctly for the given frequency by
  determing the period in nanoseconds
- Make duty_cycle setting not dependent on a given Frequency setting
  by always reading the set frequency of the driver.